### PR TITLE
MD-SAL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Configure with an initializer in config/initializers as follows:
       config.url = "http://yourserver.com:port/"
     end
 
-### Model-Driven Service Abstraction Layer (AD-SAL)
+### Model-Driven Service Abstraction Layer (MD-SAL)
 
 Consult the Yang UI from the DLux interfarce, and construct method calls similar to how they're structured in the UI:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/opendaylight.svg)](http://badge.fury.io/rb/opendaylight)
 
-This gem is made as a ruby wrapper for OpenDayligh's FlowProgrammer API
+This gem is made as a ruby wrapper for OpenDaylight MD-SAL and AD-SAL APIs, including FlowProgrammer.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -30,17 +30,25 @@ Configure with an initializer in config/initializers as follows:
 
 ### Model-Driven Service Abstraction Layer (MD-SAL)
 
-Consult the Yang UI from the DLux interfarce, and construct method calls similar to how they're structured in the UI:
+Consult the Yang UI from the DLux interfarce, and construct method calls similar to how they're structured in that UI:
 
     odl = Opendaylight::ModelDriven.new
 
     data = %q| { "flow-node-inventory:flow": [ { "flow-node-inventory:id": "foobarbaz", "flow-node-inventory:match": { . . . |
+    # POST
     result = odl.inventory.config.nodes.node("openflow:1").table('0').create data
     puts "result: " + result.class.to_s
 
+    # GET
     result = odl.inventory.config.nodes.node("openflow:1").table('0').flow("foobarbaz").resource
     puts "result: " + JSON.pretty_generate JSON.parse(result.body)
 
+    data = %q| { "flow-node-inventory:flow": [ { "flow-node-inventory:id": "foobardee", "flow-node-inventory:match": { . . . |
+    # PUT
+    result = odl.inventory.config.nodes.node("openflow:1").table('0').flow('foobardee').update data
+    puts "result: " + JSON.pretty_generate JSON.parse(result.body)
+
+    # DELETE
     result = odl.inventory.config.nodes.node("openflow:1").table('0').flow("foobarbaz").delete
     puts "result: " + result.class.to_s
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ Configure with an initializer in config/initializers as follows:
       config.url = "http://yourserver.com:port/"
     end
 
+### Model-Driven Service Abstraction Layer (AD-SAL)
+
+Consult the Yang UI from the DLux interfarce, and construct method calls similar to how they're structured in the UI:
+
+    odl = Opendaylight::ModelDriven.new
+
+    data = %q| { "flow-node-inventory:flow": [ { "flow-node-inventory:id": "foobarbaz", "flow-node-inventory:match": { . . . |
+    result = odl.inventory.config.nodes.node("openflow:1").table('0').create data
+    puts "result: " + result.class.to_s
+
+    result = odl.inventory.config.nodes.node("openflow:1").table('0').flow("foobarbaz").resource
+    puts "result: " + JSON.pretty_generate JSON.parse(result.body)
+
+    result = odl.inventory.config.nodes.node("openflow:1").table('0').flow("foobarbaz").delete
+    puts "result: " + result.class.to_s
+
+### Application-Driven Service Abstraction Layer (AD-SAL)
+
 Then make a call to Opendaylight's API.makeflow:
 
 For example:

--- a/lib/opendaylight.rb
+++ b/lib/opendaylight.rb
@@ -1,4 +1,5 @@
 require "opendaylight/version"
+require "opendaylight/model_driven"
 require "httparty"
 
 module Opendaylight

--- a/lib/opendaylight/model_driven.rb
+++ b/lib/opendaylight/model_driven.rb
@@ -1,0 +1,84 @@
+require "httparty"
+
+module Opendaylight
+
+  class ModelDriven
+    def initialize(resource_chain = nil)
+      @resource_chain = resource_chain ? resource_chain : Array.new
+      @auth = {:username => Opendaylight.configuration.username, :password => Opendaylight.configuration.password}
+    end
+
+    def create(post_data)
+      h = HTTParty.post(form_url_from_method_calls, { :basic_auth => @auth, :body => post_data, headers: {"Content-Type" => "application/json", "Accept" => "application/json"} } )
+
+      h.response
+    end
+
+    def delete
+      h = HTTParty.delete(form_url_from_method_calls, { :basic_auth => @auth } )
+
+      h.response
+    end
+
+    def method_missing(sym, *args, &block)
+      @resource_chain << sym
+      args.each do |arg|
+        @resource_chain << arg.to_s.to_sym
+      end
+      md = ModelDriven.new(@resource_chain)
+      @resource_chain = Array.new
+
+      return md
+
+      super(sym, *args, &block)
+    end
+
+    def update(object)
+      h = HTTParty.put(form_url_from_method_calls, { :basic_auth => @auth, :body => object, headers: {"Content-Type" => "application/json", "Accept" => "application/json"} } )
+
+      h.response
+    end
+
+    def respond_to?(sym, include_private = false)
+      @resource_chain << sym.to_s.to_sym
+      call_exists_in_mdsal? || super(sym, include_private)
+    end
+
+    def resource
+      url = form_url_from_method_calls
+      h = HTTParty.get(url, { :basic_auth => @auth, headers: {"Accept" => "application/json"} } )
+      h.response
+    end
+
+    private
+
+    def call_exists_in_mdsal?
+      h = HTTParty.head(form_url_from_method_calls, :basic_auth => @auth)
+      h.response.code.to_i < 400
+    end
+
+    def map_method_to_module(method)
+      case method
+      when :nodes
+        return "opendaylight-inventory:" + method.to_s
+      else
+        return method.to_s
+      end
+
+    end
+
+    def form_url_from_method_calls
+      path = Array.new
+      path << "restconf"
+      @resource_chain[1,@resource_chain.size].each do |resource|
+        path << map_method_to_module(resource)
+      end
+
+      p = URI::Parser.new
+      u = p.parse Opendaylight.configuration.url
+      u.path = '/' + path.join('/')
+      u.to_s
+    end
+
+  end
+end

--- a/lib/opendaylight/version.rb
+++ b/lib/opendaylight/version.rb
@@ -1,3 +1,3 @@
 module Opendaylight
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/opendaylight.gemspec
+++ b/opendaylight.gemspec
@@ -6,8 +6,8 @@ require 'opendaylight/version'
 Gem::Specification.new do |spec|
   spec.name          = "opendaylight"
   spec.version       = Opendaylight::VERSION
-  spec.authors       = ["rickpr"]
-  spec.email         = ["fdisk@fdisk.co"]
+  spec.authors       = ["rickpr", "aburnheimer"]
+  spec.email         = ["fdisk@fdisk.co", "aburnheimer@gmail.com"]
   spec.summary       = "Ruby Wrapper for OpenDaylight"
   spec.description   = "Makes writing Ruby apps for OpenDaylight easy"
   spec.homepage      = "http://fdisk.co"


### PR DESCRIPTION
My understanding going through the projects' documentation is the MD-SAL, based on the YANG models, is how the project would like to continue on for the northbound interface. In that way, I thought the Ruby API may be better implemented by being more free-form, relying on `ModelDriven#method_missing`, as inspired by Nokogiri [Slop](http://www.nokogiri.org/tutorials/searching_a_xml_html_document.html#slop_sup_1__sup_).

I must say, `ModelDriven#respond_to?` and `ModelDriven#call_exists_in_mdsal?`have only been conceptualized to date. That sort of thing seems like a good idea, but something tells me either it shouldn't be done in that way, or at all.

Looking forward to your thoughts. Of course, I'm not married to the code, and completely respect if you don't see it as being in the spirit of the gem. Thank you for looking into this.
